### PR TITLE
Add data seeding script and initial JSON datasets

### DIFF
--- a/backend/app/data/competitors.json
+++ b/backend/app/data/competitors.json
@@ -1,0 +1,62 @@
+[
+  {
+    "firstname": "Akbar",
+    "lastname": "Khazaei",
+    "dob": "1980-08-11"
+  },
+  {
+    "firstname": "Sandy",
+    "lastname": "Williamson",
+    "dob": ""
+  },
+  {
+    "firstname": "John",
+    "lastname": "Hnatyschak",
+    "dob": ""
+  },
+  {
+    "firstname": "Peter-John",
+    "lastname": "Rhoden",
+    "dob": ""
+  },
+  {
+    "firstname": "David",
+    "lastname": "Herskovitz",
+    "dob": ""
+  },
+  {
+    "firstname": "Serge",
+    "lastname": "Saric",
+    "dob": ""
+  },
+  {
+    "firstname": "Tim",
+    "lastname": "Gardner",
+    "dob": ""
+  },
+  {
+    "firstname": "Tony",
+    "lastname": "Curtis",
+    "dob": ""
+  },
+  {
+    "firstname": "Deke",
+    "lastname": "Warner",
+    "dob": ""
+  },
+  {
+    "firstname": "Vince",
+    "lastname": "Crawford",
+    "dob": ""
+  },
+  {
+    "firstname": "Fabian",
+    "lastname": "Orozco",
+    "dob": ""
+  },
+  {
+    "firstname": "Garron",
+    "lastname": "Whitehead",
+    "dob": ""
+  }
+]

--- a/backend/app/populate_db.py
+++ b/backend/app/populate_db.py
@@ -1,0 +1,48 @@
+import json
+
+from sqlalchemy.orm import Session
+from app.models.models import User, Competitor, Division, Judge, Competition  # adjust if paths differ
+from app.database import SessionLocal  # assumes you have a SessionLocal factory
+from passlib.hash import bcrypt
+
+competitions_fp = './app/data/competitions.json'
+divisions_fp = './app/data/divisions.json'
+judges_fp = './app/data/judges.json'
+users_fp = './app/data/users.json'
+competitors_fp = './app/data/competitors.json'
+
+paths = [[users_fp, User], [competitions_fp, Competition], [divisions_fp, Division], [judges_fp, Judge],
+         [competitors_fp, Competitor]]
+
+
+def hash_password(password):
+    return bcrypt.hash(password)
+
+
+def get_data(fp:str) -> dict:
+    data = None
+    with open(fp, 'r') as f:
+        data = json.load(f)
+    return data
+
+
+def seedData(session: Session):
+    for fp, model in paths:
+        data = get_data(fp)
+        obj = model(**data)
+        session.add(obj)
+
+    session.commit()
+
+
+def main():
+    db = SessionLocal()
+    try:
+        seedData(db)
+        print("✅ Seed data inserted successfully.")
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Introduced `populate_db.py` to seed the database with initial data for users, competitors, and other entities. Added `users.json` and `competitors.json` files to provide sample dataset templates for populating the database.

## Summary by Sourcery

Add a data seeding script to populate the database with initial datasets for various application entities

New Features:
- Created a Python script to seed the database with initial data
- Introduced JSON data files for populating different database models

Chores:
- Implemented a generic data loading mechanism for database initialization